### PR TITLE
Fixed incorrect character for markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Use this repo to share and keep track of any tech-related internships. For a [Go
 |[Twitch](https://boards.greenhouse.io/twitch/jobs/4827849002?gh_src=PittCSC)| Seattle, Irvine, San Francisco | |
 |[Snap](https://wd1.myworkdaysite.com/recruiting/snapchat/snap/job/Los-Angeles-California/Software-Engineer-Intern---Fall-2021--August-17---Sept-4-_R0014581)| Los Angeles, Seattle, San Francisco, New York, Mountain View | |
 |[Benchling](https://www.benchling.com/careers/?gh_jid=2298068&gh_src=PittCSC#detail)| San Fran, Boston | |
-|[3M](https://3m.wd1.myworkdayjobs.com/en-US/Search/job/US-New-York-Albany/Software-Engineer-Intern_R01018495）| Albany| |
+|[3M](https://3m.wd1.myworkdayjobs.com/en-US/Search/job/US-New-York-Albany/Software-Engineer-Intern_R01018495) | Albany| |
 |[Target](https://jobs.target.com/job/-/-/1118/17057382)| Minneapolis | |
 |[Emerson](https://emerson.taleo.net/careersection/autosol/jobdetail.ftl?job=20005735&lang=en&media_id=46825)| Austin,TX| |
 


### PR DESCRIPTION
This weird character "）" was used instead of ")"