### PR TITLE
Add PEAK6 internship

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ Use this repo to share and keep track of any tech-related internships. For a [Go
 |[KnowBe4](https://www.knowbe4.com/jobs?gh_jid=4858556002) | Clearwater, Florida | | 
 |[Gap](https://www.gapinc.com/en-us/jobs/33/85/undergrad-summer-internship-software-engineering?src=JB-10340&rx_source=PittCSC) | SF | |
 |[American Express](https://jobs.americanexpress.com/jobs/20006515?lang=en-us&previousLocale=en-US) | Various | |
-|[Postmates](https://join.postmates.com/careers?pid=1528316) | Remote | |
 |[Silicon Labs](https://jobs.jobvite.com/silabs/job/oyymdfwp) | Austin, TX | |
 |[Blackstone](https://blackstone.wd1.myworkdayjobs.com/Blackstone_Campus_Careers/job/New-York/XMLNAME-2021-Software-Developer-Summer-Analyst_12259) | NYC | |
+|[PEAK6](https://boards.greenhouse.io/capitalmanagement/jobs/2260071) | Chicago, IL | for those who identify as female, also have PM and trading intern positions|
 
 
 Huge shout-out to our contributors! Fill [this survey](https://bit.ly/3d5O76c), make a [Pull Request](https://github.com/susam/gitpr#create-pull-request), or submit [an issue](https://github.com/Pitt-CSC/Summer2021-Internships/issues) if you'd like to contribute too! 🙏


### PR DESCRIPTION
I'm adding the PEAK6 internship program for women but there are addition positions open for all genders.

I am also deleted Postmates (which I added) because after trying to apply, it looks like the position is for Fall 2020. Sorry I didn't catch that earlier.